### PR TITLE
Sort file list; make send2trash import optional

### DIFF
--- a/dired.py
+++ b/dired.py
@@ -4,7 +4,11 @@
 import sublime
 from sublime import Region
 from sublime_plugin import WindowCommand, TextCommand
-import os, re, shutil, tempfile, subprocess, send2trash
+import os, re, shutil, tempfile, subprocess
+try:
+    import send2trash
+except ImportError:
+    send2trash = None
 from os.path import basename, dirname, isdir, exists, join, isabs, normpath, normcase
 
 ST3 = int(sublime.version()) >= 3000
@@ -366,7 +370,7 @@ class DiredDeleteCommand(TextCommand, DiredBaseCommand):
             if trash or sublime.ok_cancel_dialog(msg):
                 for filename in files:
                     fqn = join(self.path, filename)
-                    if trash:
+                    if trash and send2trash:
                         send2trash.send2trash(fqn)
                     elif isdir(fqn):
                         shutil.rmtree(fqn)


### PR DESCRIPTION
The file list is currently unsorted (at least, it is here on Linux). This patch sorts the file list using natural sorting (http://www.codinghorror.com/blog/2007/12/sorting-for-humans-natural-sort-order.html).

Also, send2trash doesn't seem to import on my machine, even after installing using pip3, so I made it optional.
