### PR TITLE
Added `self.window.folders()` fallback to _determine_path

### DIFF
--- a/dired.py
+++ b/dired.py
@@ -125,6 +125,11 @@ class DiredCommand(WindowCommand):
             if folders:
                 return folders[0]['path']
 
+        # Use window folder if possible
+        folders = self.window.folders()
+        if len(folders) > 0:
+            return folders[0]
+
         # Use the user's home directory.
         return os.path.expanduser('~')
 


### PR DESCRIPTION
This is kinda follow up to pull request #18.  When a new window is opened, the FileBrowser currently defaults to the user's home directory.  IMO, it'd be nice if the extension checked to see if any directories are available in `self.window.folders()` before defaulting to the user's home directory.  This is handy when sublime is opened from the command line.
