### PR TITLE
Fix "'WindowsError' is not defined" error on OSX when deleting a file.

### DIFF
--- a/dired.py
+++ b/dired.py
@@ -536,7 +536,7 @@ class DiredDeleteCommand(TextCommand, DiredBaseCommand):
         if ST3:
             fail = (PermissionError, FileNotFoundError)
         else:
-            fail = (WindowsError, OSError)
+            fail = (WindowsError, OSError) if sublime.platform() == 'windows' else (OSError,)
             sys_enc = locale.getpreferredencoding(False)
         for filename in files:
             fqn = join(self.path, filename)


### PR DESCRIPTION
Happens on Sublime 2 for OSX.
