### PR TITLE
Fix custom color schemes

### DIFF
--- a/dired-rename-mode.sublime-settings
+++ b/dired-rename-mode.sublime-settings
@@ -1,0 +1,3 @@
+{
+  "color_scheme": "Packages/FileBrowser/dired-rename-mode.hidden-tmTheme"
+}

--- a/dired.py
+++ b/dired.py
@@ -863,7 +863,7 @@ class DiredRenameCommand(TextCommand, DiredBaseCommand):
             # Store the original filenames so we can compare later.
             self.view.settings().set('rename', self.get_all())
             self.view.settings().set('dired_rename_mode', True)
-            self.view.settings().set('color_scheme', 'Packages/FileBrowser/dired-rename-mode.hidden-tmTheme')
+            set_proper_scheme(self.view)
             self.view.set_read_only(False)
 
             self.set_ui_in_rename_mode(edit)
@@ -882,7 +882,7 @@ class DiredRenameCancelCommand(TextCommand, DiredBaseCommand):
     """
     def run(self, edit):
         self.view.settings().erase('rename')
-        self.view.settings().set('color_scheme', 'Packages/FileBrowser/dired.hidden-tmTheme')
+        set_proper_scheme(self.view)
         self.view.settings().set('dired_rename_mode', False)
         self.view.run_command('dired_refresh')
 
@@ -958,7 +958,7 @@ class DiredRenameCommitCommand(TextCommand, DiredBaseCommand):
 
         self.view.erase_regions('rename')
         self.view.settings().erase('rename')
-        self.view.settings().set('color_scheme', 'Packages/FileBrowser/dired.hidden-tmTheme')
+        set_proper_scheme(self.view)
         self.view.settings().set('dired_rename_mode', False)
         self.view.run_command('dired_refresh')
 
@@ -1026,7 +1026,7 @@ class DiredHelpCommand(TextCommand):
         view.settings().add_on_change('color_scheme', lambda: set_proper_scheme(view))
         view.set_name("Browse: shortcuts")
         view.set_scratch(True)
-        view.settings().set('color_scheme','Packages/FileBrowser/dired.hidden-tmTheme')
+        set_proper_scheme(view)
         view.settings().set('syntax','Packages/FileBrowser/dired-help.hidden-tmLanguage')
         view.settings().set('line_numbers',False)
         view.run_command('dired_show_help')

--- a/jumping.py
+++ b/jumping.py
@@ -12,10 +12,12 @@ if ST3:
     from .common import DiredBaseCommand
     from . import prompt
     from .show import show
+    from .show import set_proper_scheme
 else:
     from common import DiredBaseCommand
     import prompt
     from show import show
+    from show import set_proper_scheme
 
 
 def load_jump_points():
@@ -183,7 +185,7 @@ class DiredJumpListCommand(TextCommand):
         view.set_name("FileBrowser: Jump List")
         view.set_scratch(True)
         view.set_syntax_file('Packages/FileBrowser/dired_jumplist.hidden-tmLanguage')
-        view.settings().set('color_scheme','Packages/FileBrowser/dired.hidden-tmTheme')
+        set_proper_scheme(view)
         view.settings().set('line_numbers', False)
         view.settings().set('draw_centered', True)
         view.run_command('dired_jump_list_render')

--- a/show.py
+++ b/show.py
@@ -16,10 +16,15 @@ else:
 def set_proper_scheme(view):
     # Since we cannot create file with syntax, there is moment when view has no settings,
     # but it is activated, so some plugins (e.g. Color Highlighter) set wrong color scheme
+
+    dired_settings = None
+
     if view.settings().get('dired_rename_mode'):
-        view.settings().set('color_scheme', 'Packages/FileBrowser/dired-rename-mode.hidden-tmTheme')
+        dired_settings = sublime.load_settings('dired-rename-mode.sublime-settings')
     else:
-        view.settings().set('color_scheme', sublime.load_settings('dired.sublime-settings').get('color_scheme'))
+        dired_settings = sublime.load_settings('dired.sublime-settings')
+
+    view.settings().set('color_scheme', dired_settings.get('color_scheme'))
 
 
 def show(window, path, view_id=None, ignore_existing=False, single_pane=False, goto=None, other_group=''):


### PR DESCRIPTION
This prevent the plugin to override the custom theme set in the user’s `dired.sublime-settings` file with the default one. Also let the user use a custom theme for rename mode.

The `dired-rename-mode.sublime-settings` file could be used for rename mode specific settings in the future but maybe it’s not necessary ? Would you rather prefer a `rename_mode_color_scheme` key inside `dired.sublime-settings` or something similar ? It’s simpler to toggle the color scheme with an external plugin this way though (nice for dark/light variations).