### PR TITLE
Reuse empty windows when jumping

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,10 @@ You can change `f3` in the above code to your custom keyboard shortcut.
           The view opens as a left sidebar by default. To change it add `dired_open_on_jump` to your
           user settings file (`Preferences` → `Package Settings` → `FileBrowser` → `Settings — User`).
           Set it to `"right"` to open the view as sidebar on the right side of the window or
-          to `true` to fill all space. A value of `false` will prevent any view to open when jumping.
+          to `true` to fill all space. A value of `false` will prevent any view to open when jumping.  
+          To open the directory in the same window call the command with `false`.
+          To keep the current window if it is empty call the command with `"auto"`
+          and edit your user settings with `"dired_smart_jump": true`.
 
 ##### Jump List View
 Bring up *Command Palette* and search for `Browse Mode: Jump List` (typing `bmj` should find it for
@@ -236,8 +239,7 @@ If you want to save some key stokes you can add the following code in your user 
 
 You can change `f3` in the above code to your custom keyboard shortcut.
 Jump List View can be browsed using the <kbd>up</kbd>/<kbd>down</kbd> or <kbd>j</kbd>/<kbd>k</kbd>.
-Pressing <kbd>enter</kbd> on a jump point will open it in a new window with a Browse Mode view as
-sidebar or what was configured with `dired_open_on_jump`.
+Pressing <kbd>enter</kbd> on a jump point will open it in a new window with a Browse Mode view as sidebar or what was configured with `dired_open_on_jump`. Empty windows will be reused if `dired_smart_jump` is set to `true` in your user settings.
 
 ##### Jump List in a new empty window e.g. Hijacking (ST3 only)
 You can also configure FileBrower to automatically open *Jump List View*  in new empty windows.

--- a/dired.sublime-commands
+++ b/dired.sublime-commands
@@ -15,7 +15,7 @@
   {
     "caption": "Browse Mode: Jump List Quick Panel",
     "command": "dired_jump",
-    "args": { "new_window": true }
+    "args": { "new_window": "auto" }
   },
   {
     "caption": "Browse Mode: Left Sidebar",

--- a/dired.sublime-settings
+++ b/dired.sublime-settings
@@ -44,6 +44,10 @@
   // false: don’t open any view
   "dired_open_on_jump": "left",
 
+  // true: keep the active window if empty when jumping
+  // false: the default, always open a new window when jumping
+  "dired_smart_jump": false,
+
   // Automatically disable Vintageous to avoid keybindings incompatibilities;
   // note it is Vintageous setting, if it does not work you should report into
   // appropriate repository https://github.com/guillermooo/Vintageous/issues

--- a/jumping.py
+++ b/jumping.py
@@ -72,7 +72,10 @@ class DiredJumpCommand(TextCommand, DiredBaseCommand):
             return
         name, target = self.jump_points[index]
         if exists(target) and isdir(target) and target[-1] == os.sep:
-            if self.new_window:
+            settings = load_settings('dired.sublime-settings')
+            smart_jump = settings.get('dired_smart_jump', False)
+            auto = self.new_window == 'auto'
+            if self.new_window == True or ((not smart_jump) and auto) or (smart_jump and auto and len(self.view.window().views()) > 0):
                 print(target)
                 self.view.run_command("dired_open_in_new_window", {"project_folder": [target]})
             else:
@@ -226,7 +229,12 @@ class DiredProjectSelectCommand(TextCommand):
         row, col = self.view.rowcol(pt)
         points = [[n, t] for n, t in jump_points()]
         current_project = [points[row - 3][1]]
-        self.view.run_command("dired_open_in_new_window", {"project_folder": current_project})
+        settings = load_settings('dired.sublime-settings')
+        smart_jump = settings.get('dired_smart_jump', False)
+        if smart_jump and len(self.view.window().views()) == 1:
+            show(self.view.window(), current_project[0])
+        else:
+            self.view.run_command("dired_open_in_new_window", {"project_folder": current_project})
 
         def close_view(view):
             if ST3:


### PR DESCRIPTION
This prevents the plugin to open a new window when jumping (both from the quick panel and the Jump List view) if the window is empty and can be reused instead. The window is considered empty if
```
len(view.window.views()) == 0
```
when jumping from the quick panel and if
```
len(view.window.views()) == 1
```
when jumping from the Jump List view.

Those changes are backward compatibles, calling `dired_jump` with `{ "new_window": "auto" }` is equivalent to `{ "new_window": true }` if `dired_smart_jump` isn’t set.

The name `dired_smart_jump` was catchy and I like it quite a bit but maybe should we rename it to something more descriptive like `dired_reuse_empty_window_on_jump` ?
