### PR TITLE
Make configurable the Browse View opened on jump

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,11 @@ If you want to save some key stokes you can add the following code in your user 
 
 You can change `f3` in the above code to your custom keyboard shortcut.
 
-**NOTE**: This command creates a new window and open that directory in Sublime. It also opens a
-          Browse Mode view as sidebar.
+**NOTE**: This command creates a new window and open that directory in Sublime with a Browse Mode view.
+          The view opens as a left sidebar by default. To change it add `dired_open_on_jump` to your
+          user settings file (`Preferences` → `Package Settings` → `FileBrowser` → `Settings — User`).
+          Set it to `"right"` to open the view as sidebar on the right side of the window or
+          to `true` to fill all space. A value of `false` will prevent any view to open when jumping.
 
 ##### Jump List View
 Bring up *Command Palette* and search for `Browse Mode: Jump List` (typing `bmj` should find it for
@@ -234,7 +237,7 @@ If you want to save some key stokes you can add the following code in your user 
 You can change `f3` in the above code to your custom keyboard shortcut.
 Jump List View can be browsed using the <kbd>up</kbd>/<kbd>down</kbd> or <kbd>j</kbd>/<kbd>k</kbd>.
 Pressing <kbd>enter</kbd> on a jump point will open it in a new window with a Browse Mode view as
-sidebar.
+sidebar or what was configured with `dired_open_on_jump`.
 
 ##### Jump List in a new empty window e.g. Hijacking (ST3 only)
 You can also configure FileBrower to automatically open *Jump List View*  in new empty windows.

--- a/dired.py
+++ b/dired.py
@@ -1120,7 +1120,16 @@ class DiredOpenInNewWindowCommand(TextCommand, DiredBaseCommand):
                     subprocess.Popen(['sublime'] + items, cwd=self.path)
 
         def run_on_new_window():
-            sublime.active_window().run_command("dired", {"immediate": True, "project": True, "other_group": "left"})
+            settings = sublime.load_settings('dired.sublime-settings')
+            open_on_jump = settings.get('dired_open_on_jump', 'left')
+
+            if open_on_jump:
+                options = {"immediate": True, "project": True}
+
+                if open_on_jump in ['left', 'right']:
+                    options["other_group"] = open_on_jump
+
+                sublime.active_window().run_command("dired", options)
 
         sublime.set_timeout(run_on_new_window, 200)
         if not ST3:

--- a/dired.sublime-settings
+++ b/dired.sublime-settings
@@ -37,6 +37,13 @@
   // false: a new view is created.
   "dired_reuse_view": true,
 
+  // How should be positioned the Browse Mode view opened when jumping
+  // "left": the default, open the view on the left
+  // "right": open the view on the right
+  // true: take all space available
+  // false: don’t open any view
+  "dired_open_on_jump": "left",
+
   // Automatically disable Vintageous to avoid keybindings incompatibilities;
   // note it is Vintageous setting, if it does not work you should report into
   // appropriate repository https://github.com/guillermooo/Vintageous/issues


### PR DESCRIPTION
This allows the user to configure how the File Browser view opened when jumping should be positioned:
+ `"left"` open the view on the left (this is the default setting today)
+ `"right"` open the view on the right
+ `true` take all space available
+ `false` don’t open any view

Those changes are backward compatibles, `dired_open_on_jump ` fallbacks to `"left"` if it isn’t set.