### PR TITLE
fix FileBrowser view when used in a project with multiple folders

### DIFF
--- a/common.py
+++ b/common.py
@@ -526,7 +526,8 @@ class DiredBaseCommand:
 
         self.view.show_at_center(s)
 
-    def display_path(self, folder):
+    @staticmethod
+    def display_path(folder):
         display = folder
         home = os.path.expanduser("~")
         if folder.startswith(home):

--- a/common.py
+++ b/common.py
@@ -526,8 +526,7 @@ class DiredBaseCommand:
 
         self.view.show_at_center(s)
 
-    @staticmethod
-    def display_path(folder):
+    def display_path(self, folder):
         display = folder
         home = os.path.expanduser("~")
         if folder.startswith(home):

--- a/dired.py
+++ b/dired.py
@@ -57,7 +57,7 @@ if not ST3:
     plugin_loaded()
 
 
-class DiredCommand(WindowCommand):
+class DiredCommand(WindowCommand, DiredBaseCommand):
     """
     Prompt for a directory to display and display it.
     """
@@ -73,7 +73,7 @@ class DiredCommand(WindowCommand):
                 for i, f in enumerate(folders):
                     name     = names[i]
                     offset   = ' ' * (longest_name - len(name) + 1)
-                    names[i] = u'%s%s%s' % (name, offset, DiredBaseCommand.display_path(f))
+                    names[i] = u'%s%s%s' % (name, offset, self.display_path(f))
                 self.window.show_quick_panel(names, lambda i: self._show_folder(i, path, goto, single_pane, other_group), sublime.MONOSPACE_FONT)
                 return
         if immediate:

--- a/dired.py
+++ b/dired.py
@@ -73,7 +73,7 @@ class DiredCommand(WindowCommand):
                 for i, f in enumerate(folders):
                     name     = names[i]
                     offset   = ' ' * (longest_name - len(name) + 1)
-                    names[i] = u'%s%s%s' % (name, offset, self.display_path(f))
+                    names[i] = u'%s%s%s' % (name, offset, DiredBaseCommand.display_path(f))
                 self.window.show_quick_panel(names, lambda i: self._show_folder(i, path, goto, single_pane, other_group), sublime.MONOSPACE_FONT)
                 return
         if immediate:


### PR DESCRIPTION
This error occurs when attempting to use FileBrowser in a project with multiple folders defined:

```
AttributeError: 'DiredCommand' object has no attribute 'display_path'
```

Since `common.DiredBaseCommand.display_path` is called from multiple files and does not use self, the fix converts the `common.DiredBaseCommand.display_path` to a static method.
