### PR TITLE
Use specific icons for each file type

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -331,7 +331,7 @@
       "context": [
         { "key": "selector", "operator": "equal", "operand": "text.dired" },
         { "key": "setting.dired_rename_mode", "operand": true },
-        { "key": "preceding_text", "operator": "regex_contains", "operand": "[≡▸▾]\\s*$|^\\s*$|^⠤.*$"}
+        { "key": "preceding_text", "operator": "regex_contains", "operand": "[≡▸▾]\\s*$|^\\s*$|^\\s*\\S\\s$|^⠤.*$"}
       ]
   },
   {

--- a/common.py
+++ b/common.py
@@ -239,7 +239,7 @@ class DiredBaseCommand:
     def _get_name_point(self, line):
         '''Return point at which filename starts (i.e. after icon & whitspace)'''
         scope = self.view.scope_name(line.a)
-        if 'string' not in scope:
+        if 'indent' in scope:
             name_point = self.view.extract_scope(line.a).b
         else:
             name_point = line.a + (2 if not 'parent_dir' in scope else 0)

--- a/common.py
+++ b/common.py
@@ -418,6 +418,7 @@ class DiredBaseCommand:
         files   = []
         index_dirs  = []
         index_files = []
+        icons = sublime.load_settings('dired.sublime-settings').get('dired_icons', {})
         for name in names:
             full_name = join(path, goto, name)
             if isdir(full_name):
@@ -425,7 +426,8 @@ class DiredBaseCommand:
                 items.append(''.join([level, u"▸ ", name, os.sep]))
             else:
                 index_files.append(full_name)
-                files.append(''.join([level, u"≡ ", name]))
+                icon = icons.get(name.split('.')[-1], '≡')
+                files.append(''.join([level, icon, ' ', name]))
         index = index_dirs + index_files
         self.index = self.index[:self.number_line] + index + self.index[self.number_line:]
         items += files
@@ -535,7 +537,7 @@ class DiredBaseCommand:
             pattern = u'^\s*[▸▾] '
             sep = re.escape(os.sep)
         else:
-            pattern = u'^\s*≡ '
+            pattern = r'^\s*\S '
             sep = ''
         return self.view.find_all(u'%s%s%s' % (pattern, fname, sep))
 

--- a/common.py
+++ b/common.py
@@ -239,7 +239,7 @@ class DiredBaseCommand:
     def _get_name_point(self, line):
         '''Return point at which filename starts (i.e. after icon & whitspace)'''
         scope = self.view.scope_name(line.a)
-        if 'indent' in scope:
+        if 'string' not in scope:
             name_point = self.view.extract_scope(line.a).b
         else:
             name_point = line.a + (2 if not 'parent_dir' in scope else 0)

--- a/dired.hidden-tmLanguage
+++ b/dired.hidden-tmLanguage
@@ -52,7 +52,7 @@
 
       <dict>
           <key>match</key>
-          <string>^(\s*)(≡ )(\S.*?(\.[^\.\n]+)?)$</string>
+          <string>^(\s*)(\S )(\S.*?(\.[^\.\n]+)?)$</string>
           <key>name</key>
           <string>dired.item.file</string>
           <key>captures</key>

--- a/dired.py
+++ b/dired.py
@@ -306,6 +306,8 @@ class DiredRefreshCommand(TextCommand, DiredBaseCommand):
             else:
                 index_files.append(new_path)
                 icon = icons.get(f.split(".")[-1], "≡")
+                # Ensure icon are 1 char long
+                icon = icon[0]
                 files.append(u'%s%s %s' % (indent, icon, f))
 
         self.index += index_files

--- a/dired.py
+++ b/dired.py
@@ -291,6 +291,7 @@ class DiredRefreshCommand(TextCommand, DiredBaseCommand):
                 tree[~0] += '\t<empty>'
                 return
 
+        icons = sublime.load_settings('dired.sublime-settings').get('dired_icons', {})
         files = []
         index_files = []
         for f in items:
@@ -304,7 +305,8 @@ class DiredRefreshCommand(TextCommand, DiredBaseCommand):
                 tree.append(u'%s▸ %s%s' % (indent, f.rstrip(os.sep), os.sep))
             else:
                 index_files.append(new_path)
-                files.append(u'%s≡ %s' % (indent, f))
+                icon = icons.get(f.split(".")[-1], "≡")
+                files.append(u'%s%s %s' % (indent, icon, f))
 
         self.index += index_files
         tree += files

--- a/dired.py
+++ b/dired.py
@@ -685,6 +685,9 @@ class DiredFold(TextCommand, DiredBaseCommand):
             end_line   = start_line + removed_count
             self.index = self.index[:start_line] + self.index[end_line:]
             v.settings().set('dired_index', self.index)
+        else:
+            # I'm not sure this is the right behavior.
+            start_line = 1 + v.rowcol(line.a)[0]
 
         if self.marked or self.seled:
             path = self.path
@@ -695,7 +698,11 @@ class DiredFold(TextCommand, DiredBaseCommand):
                 self.seled[0].append(folded_name)
 
         name_point  = self._get_name_point(line)
-        icon_region = Region(name_point - 2, name_point - 1)
+        if v.substr(name_point) == "▾":
+            # I'm not sure why but sometimes get_name_point returns the icon
+            icon_region = Region(name_point, name_point + 1)
+        else:
+            icon_region = Region(name_point - 2, name_point - 1)
 
         v.set_read_only(False)
         v.replace(edit, icon_region, u'▸')

--- a/dired.sublime-settings
+++ b/dired.sublime-settings
@@ -70,6 +70,11 @@
   // Only for OSX and Linux.
   "dired_dup_separator": " — ",
 
+  // Map file extensions to a specific icon.
+  // Works best with an extended font from https://www.nerdfonts.com/
+  // Example: "dired_icons": { "json": "", "md": "", "py": "", "zip": ""},
+  "dired_icons": {},
+
   // Automatically disable Vintageous to avoid keybindings incompatibilities;
   // note it is Vintageous setting, if it does not work you should report into
   // appropriate repository https://github.com/guillermooo/Vintageous/issues

--- a/dired.sublime-syntax
+++ b/dired.sublime-syntax
@@ -15,7 +15,7 @@ contexts:
         3: string.name.directory.dired
         4: punctuation.definition.directory.slash.dired
         5: string.error.dired
-    - match: '^(\s*)(≡ )(\S.*?(\.[^\.\n]+)?)$'
+    - match: '^(\s*)(\S+) (\S.*?(\.[^\.\n]+)?)$'
       scope: dired.item.file
       captures:
         1: indent

--- a/dired.sublime-syntax
+++ b/dired.sublime-syntax
@@ -15,7 +15,7 @@ contexts:
         3: string.name.directory.dired
         4: punctuation.definition.directory.slash.dired
         5: string.error.dired
-    - match: '^(\s*)(\S+) (\S.*?(\.[^\.\n]+)?)$'
+    - match: '^(\s*)(\S )(\S.*?(\.[^\.\n]+)?)$'
       scope: dired.item.file
       captures:
         1: indent

--- a/dired_file_operations.py
+++ b/dired_file_operations.py
@@ -255,7 +255,7 @@ class DiredRenameCommitCommand(TextCommand, DiredBaseCommand):
         before = self.view.settings().get('rename')
         # We marked the set of files with a region.  Make sure the region still has the same
         # number of files.
-        after  = self.get_after()
+        after = self.get_after()
 
         if len(after) != len(before):
             return sublime.error_message('You cannot add or remove lines')
@@ -276,7 +276,10 @@ class DiredRenameCommitCommand(TextCommand, DiredBaseCommand):
         self.index = self.get_all()
         path = self.path
         lines = self._get_lines(self.view.get_regions('rename'), self.fileregion())
-        return [self._new_name(line, path=path) for line in lines]
+        lines = [self._new_name(line, path=path) for line in lines]
+        assert '[RENAME MODE]' in lines[0], "Please don't edit the header '[RENAME MODE]' '" + lines[0] + "'"
+        lines = lines[1:]
+        return lines
 
     def _new_name(self, line, path=None, full=False):
         '''Return new name for line


### PR DESCRIPTION
Hi, this PR is more a proof of concept right now I haven't properly tested it, particularly with ST2.
I'm opening this to check the interest and get early feedback on how this should be implemented and what can possibly go wrong.

The idea is to replace the generic `≡` file prefix with something that depends on the file extension.
Using this with [Nerd fonts](https://www.nerdfonts.com) it can results in a menu like this:

<img width="406" alt="Screen Shot 2019-11-29 at 16 35 11" src="https://user-images.githubusercontent.com/5920036/69879162-0a5ed380-12c7-11ea-88e3-87c5dca29d34.png">

Here is what my settings file looks like (which render as garbage unless you have the correct font):

```
{
	"color_scheme": "Packages/User/scalaSublimeSyntax/Espresso2.tmTheme",
	"dired_icons":
	{
		"gitignore": "",
		"hidden-tmLanguage": "謹",
		"json": "",
		"LICENSE": "",
		"md": "",
		"py": "",
		"sublime-keymap": "\ue7aa",
		"sublime-menu": "\ue7aa",
		"sublime-settings": "\ue7aa",
		"sublime-syntax": "\ue7aa",
		"tmLanguage": "謹",
		"tmPreferences": "謹",
		"txt": "",
		"xml": "謹",
		"zip": ""
	},
	"font_face": "FuraCode Nerd Font Mono"
}
```

The mixed unicode characters and escape is because settings files are overriden by FileBrowser plugin in a way that doesn't preserved the escaping. I'm not sure what the best way to share this.
You can find unicode for an icon with the [Nerd Fonts search tool](https://www.nerdfonts.com/cheat-sheet).