### PR TITLE
Ensure `goto` is relative to the root `path`

### DIFF
--- a/dired.py
+++ b/dired.py
@@ -123,7 +123,7 @@ class DiredCommand(WindowCommand, DiredBaseCommand):
             for f in folders:
                 # e.g. ['/a', '/aa'], to open '/aa/f' we need '/aa/'
                 if path.startswith(u''.join([f, os.sep])):
-                    return (f, path)
+                    return (f, os.path.relpath(path, f))
             return os.path.split(path)
 
         # Use the first project folder if there is one.


### PR DESCRIPTION
Dired views have a root (on `self.path`) and then possibly a `goto` path which is some file below the root.

Ensure the constructor `DiredCommand` sets a relative `goto` path, otherwise all folders up to the file system root will be watched. **(!)**

While navigating, `goto` was always relative to the view's root already, so only `DiredCommand` needs to be changed.

See also the doc for `DiredRefreshCommand.expand_goto` which clearly assumes relative paths for `self.goto`.