### PR TITLE
Do not use raw `project_data()` to determine "folders"

### DIFF
--- a/dired.py
+++ b/dired.py
@@ -127,14 +127,7 @@ class DiredCommand(WindowCommand, DiredBaseCommand):
             return os.path.split(path)
 
         # Use the first project folder if there is one.
-        data = self.window.project_data() if ST3 else None
-        if data and 'folders' in data:
-            folders = data['folders']
-            if folders:
-                return (folders[0]['path'], '')
-
-        # Use window folder if possible
-        if len(folders) > 0:
+        if folders:
             return (folders[0], '')
 
         # Use the user's home directory.


### PR DESCRIPTION
In fact, `window.folders()` should have the same content as the `project_data` (if a project is even loaded) *but* project data can point to relative folders, e.g. `path = "."`, and in that case we're somewhat struck but Sublime translates that in `folders()` for us.